### PR TITLE
Update keypass login pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_size = 2
 indent_size = 2
 
 [*.ftl]
-indent_size = 2
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/theme/nl-design-system/login/login-password.ftl
+++ b/theme/nl-design-system/login/login-password.ftl
@@ -1,0 +1,59 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password'); section>
+    <#if section = "header">
+        ${msg("doLogIn")}
+    <#elseif section = "form">
+        <hr class="rvo-hr"/>
+        <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+              method="post">
+            <div class="utrecht-form-fieldset rvo-form-fieldset">
+                <fieldset class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset">
+                    <div
+                        role="group"
+                        aria-labelledby="fieldA-label"
+                        class="utrecht-form-field utrecht-form-field--text rvo-form-field"
+                    >
+                        <div class="rvo-form-field__label">
+                            <label for="password" class="rvo-label" id="password-label" for="password">${msg("password")}</label>
+                            <#if messagesPerField.existsError('password')>
+                                <span id="input-error-password" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                    ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                                </span>
+                            </#if>
+                        </div>
+                        <div class="rvo-layout-row rvo-layout-gap--0">
+                            <input tabindex="2" id="password" class="${properties.kcInputClass!} utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg" name="password"
+                                   type="password" autocomplete="on" autofocus dir="auto"
+                                   aria-invalid="<#if messagesPerField.existsError('password')>true</#if>"
+                            />
+                            <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="${msg('showPassword')}"
+                                    aria-controls="password"  data-password-toggle
+                                    data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}" data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
+                                    data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
+                                <i class="${properties.kcFormPasswordVisibilityIconShow!}" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                        <div id="kc-form-options">
+                        </div>
+                        <div class="${properties.kcFormOptionsWrapperClass!}">
+                            <#if realm.resetPasswordAllowed>
+                                <span><a tabindex="5"
+                                         href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                            </#if>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <br/>
+            <p class="utrecht-button-group">
+                <input tabindex="4" class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+            </p>
+        </form>
+
+        <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+    </#if>
+
+</@layout.registrationLayout>

--- a/theme/nl-design-system/login/login-username.ftl
+++ b/theme/nl-design-system/login/login-username.ftl
@@ -18,28 +18,24 @@
                                         <label for="username"
                                                id="username-label"
                                                class="rvo-label"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+                                        <#if messagesPerField.existsError('username')>
+                                            <div class="utrecht-form-field-description utrecht-form-field-description--invalid rvo-form-feedback rvo-form-feedback--error">
+                                            <span
+                                                class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--md rvo-status-icon-foutmelding rvo-status-icon-foutmelding"
+                                                role="img"
+                                                aria-label="Foutmelding"
+                                            ></span>
+                                                ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                                            </div>
+                                        </#if>
                                     </div>
 
                                     <input tabindex="1" id="username"
                                            aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
-                                           class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg" name="username"
+                                           class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg"
+                                           name="username"
                                            value="${(login.username!'')}"
                                            type="text" autofocus autocomplete="off" dir="auto"/>
-
-                                    <#if messagesPerField.existsError('username')>
-                                        <div class="rvo-alert rvo-alert--error rvo-alert--padding-md">
-                                            <span
-                                                class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--xl rvo-status-icon-foutmelding"
-                                                role="img"
-                                                aria-label="Info"
-                                            ></span>
-                                            <div class="rvo-alert-text">
-                                                <span id="input-error-username" aria-live="polite">
-                                                    ${kcSanitize(messagesPerField.get('username'))?no_esc}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </#if>
                                 </div>
                             </#if>
 
@@ -83,22 +79,24 @@
     <#elseif section = "socialProviders" >
         <#if realm.password && social?? && social.providers?has_content>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-                <hr/>
-                <h4>${msg("identity-provider-login-label")}</h4>
+                <hr class="rvo-hr"/>
+                <h4 class="utrecht-heading-4">${msg("identity-provider-login-label")}</h4>
 
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
-                    <#list social.providers as p>
-                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                                type="button" href="${p.loginUrl}">
-                            <#if p.iconClasses?has_content>
-                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
-                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
+                <div class="rvo-layout-column rvo-layout-align-items-center rvo-layout-gap--md">
+                    <#list social.providers as provider>
+                        <a id="social-${provider.alias}"
+                           class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-full-width rvo-button-group__align-right utrecht-button--rvo-md rvo-link--no-underline"
+                           type="button" href="${provider.loginUrl}">
+                            <#if provider.iconClasses?has_content>
+                                <span class="utrecht-icon rvo-margin-inline-end--2xs rvo-icon rvo-icon--md rvo-icon--hemelblauw ${properties.kcCommonLogoIdP!} ${provider.iconClasses!}" role="img"></span>
+                                <span
+                                    class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${provider.displayName!}</span>
                             <#else>
-                                <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
+                                <span class="${properties.kcFormSocialAccountNameClass!}">${provider.displayName!}</span>
                             </#if>
                         </a>
                     </#list>
-                </ul>
+                </div>
             </div>
         </#if>
     </#if>

--- a/theme/nl-design-system/login/login-username.ftl
+++ b/theme/nl-design-system/login/login-username.ftl
@@ -1,0 +1,106 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
+    <#if section = "header">
+        ${msg("loginAccountTitle")}
+    <#elseif section = "form">
+        <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+            <div class="rvo-form-layout">
+                <#if realm.password>
+                    <div class="utrecht-form-fieldset rvo-form-fieldset">
+                        <fieldset class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset">
+                            <#if !usernameHidden??>
+                                <div
+                                    role="group"
+                                    aria-labelledby="fieldId-label"
+                                    class="utrecht-form-field utrecht-form-field--text rvo-form-field"
+                                >
+                                    <div class="rvo-form-field__label">
+                                        <label for="username"
+                                               id="username-label"
+                                               class="rvo-label"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+                                    </div>
+
+                                    <input tabindex="1" id="username"
+                                           aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                                           class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg" name="username"
+                                           value="${(login.username!'')}"
+                                           type="text" autofocus autocomplete="off" dir="auto"/>
+
+                                    <#if messagesPerField.existsError('username')>
+                                        <div class="rvo-alert rvo-alert--error rvo-alert--padding-md">
+                                            <span
+                                                class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--xl rvo-status-icon-foutmelding"
+                                                role="img"
+                                                aria-label="Info"
+                                            ></span>
+                                            <div class="rvo-alert-text">
+                                                <span id="input-error-username" aria-live="polite">
+                                                    ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </#if>
+                                </div>
+                            </#if>
+
+                            <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                                <div id="kc-form-options">
+                                    <#if realm.rememberMe && !usernameHidden??>
+                                        <div class="checkbox">
+                                            <label>
+                                                <#if login.rememberMe??>
+                                                    <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"
+                                                           checked> ${msg("rememberMe")}
+                                                <#else>
+                                                    <input tabindex="3" id="rememberMe" name="rememberMe"
+                                                           type="checkbox"> ${msg("rememberMe")}
+                                                </#if>
+                                            </label>
+                                        </div>
+                                    </#if>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+
+                    <br />
+
+                    <p class="utrecht-button-group">
+                        <input tabindex="4"
+                               class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md"
+                               name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                    </p>
+                </#if>
+            </div>
+        </form>
+
+    <#elseif section = "info" >
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+            <div id="kc-registration">
+                <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+            </div>
+        </#if>
+    <#elseif section = "socialProviders" >
+        <#if realm.password && social?? && social.providers?has_content>
+            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+                <hr/>
+                <h4>${msg("identity-provider-login-label")}</h4>
+
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
+                    <#list social.providers as p>
+                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                                type="button" href="${p.loginUrl}">
+                            <#if p.iconClasses?has_content>
+                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
+                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
+                            <#else>
+                                <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
+                            </#if>
+                        </a>
+                    </#list>
+                </ul>
+            </div>
+        </#if>
+    </#if>
+
+</@layout.registrationLayout>

--- a/theme/nl-design-system/login/login.ftl
+++ b/theme/nl-design-system/login/login.ftl
@@ -4,120 +4,119 @@
         ${msg("loginAccountTitle")}
     <#elseif section == "form">
         <div id="kc-form">
-          <div class="rvo-layout-column rvo-layout-gap--md">
-            <#if realm.password>
-              <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-              <div class="rvo-layout-column rvo-layout-gap--md">
-                <div class="utrecht-form-fieldset rvo-form-fieldset">
-                  <fieldset class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset">
+            <div class="rvo-layout-column rvo-layout-gap--md">
+                <#if realm.password>
+                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                        <div class="rvo-layout-column rvo-layout-gap--md">
+                            <div class="utrecht-form-fieldset rvo-form-fieldset">
+                                <fieldset class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset">
 
-                    <#if !usernameHidden??>
-                      <div role="group" aria-labelledby="username-label" class="utrecht-form-field utrecht-form-field--text rvo-form-field">
-                        <div class="rvo-form-field__label">
-                          <label class="rvo-label" id="username-label" for="username"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
-                          <#if messagesPerField.existsError('username','password')>
-                            <div class="utrecht-form-field-description utrecht-form-field-description--invalid rvo-form-feedback rvo-form-feedback--error">
-                              <span id="input-error" class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--md rvo-status-icon-foutmelding rvo-status-icon-foutmelding" aria-live="polite" role="img" aria-label="Foutmelding"></span>
-                              ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                    <#if !usernameHidden??>
+                                        <div role="group" aria-labelledby="username-label" class="utrecht-form-field utrecht-form-field--text rvo-form-field">
+                                            <div class="rvo-form-field__label">
+                                                <label class="rvo-label" id="username-label" for="username"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+                                                <#if messagesPerField.existsError('username','password')>
+                                                    <div class="utrecht-form-field-description utrecht-form-field-description--invalid rvo-form-feedback rvo-form-feedback--error">
+                                                        <span id="input-error"  class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--md rvo-status-icon-foutmelding rvo-status-icon-foutmelding" aria-live="polite" role="img"  aria-label="Foutmelding"></span>
+                                                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                                    </div>
+                                                </#if>
+                                            </div>
+                                            <input tabindex="2" id="username" name="username" placeholder="" type="text"  class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg" autofocus autocomplete="username" dir="auto" value="${(login.username!'')}" aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"/>
+                                        </div>
+                                    </#if>
+
+                                    <div role="group" aria-labelledby="password-label"  class="utrecht-form-field utrecht-form-field--text rvo-form-field">
+                                        <div class="rvo-form-field__label">
+                                            <label class="rvo-label" id="password-label" for="password">${msg("password")}</label>
+                                            <#if usernameHidden?? && messagesPerField.existsError('username','password')>
+                                                <div class="utrecht-form-field-description utrecht-form-field-description--invalid rvo-form-feedback rvo-form-feedback--error">
+                                                    <span id="input-error" class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--md rvo-status-icon-foutmelding rvo-status-icon-foutmelding" aria-live="polite" role="img" aria-label="Foutmelding"></span>
+                                                    ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                                </div>
+                                            </#if>
+                                        </div>
+                                        <input tabindex="3" id="password" name="password" placeholder="" type="password" autocomplete="current-password" class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg" aria-label="${msg("showPassword")}" aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"/>
+                                    </div>
+                                    <#if realm.resetPasswordAllowed>
+                                        <div role="group" aria-labelledby="password-label" class="utrecht-form-field utrecht-form-field--text rvo-form-field" style="margin-block-start: -1em;">
+                                            <div class="rvo-form-field__label">
+                                                <a class="rvo-link" tabindex="6" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a>
+                                            </div>
+                                        </div>
+                                    </#if>
+
+                                    <#if realm.rememberMe && !usernameHidden??>
+                                        <div class="rvo-checkbox__group">
+                                            <label class="rvo-checkbox rvo-checkbox--not-checked" for="optionA-cb">
+                                                <#if login.rememberMe??>
+                                                    <input tabindex="5" class="rvo-checkbox__input" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                                <#else>
+                                                    <input tabindex="5" class="rvo-checkbox__input" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                                </#if>
+                                            </label>
+                                        </div>
+                                    </#if>
+                                </fieldset>
                             </div>
-                          </#if>
+
+                            <p class="utrecht-button-group ">
+                                <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+                                <input tabindex="7" class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                            </p>
+                            <div></div>
                         </div>
-                        <input  tabindex="2" id="username" name="username" placeholder="" type="text" class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg"  autofocus autocomplete="username" dir="auto" value="${(login.username!'')}"  aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"/>
-                      </div>
-                    </#if>
-
-                    <div role="group" aria-labelledby="password-label" class="utrecht-form-field utrecht-form-field--text rvo-form-field">
-                      <div class="rvo-form-field__label">
-                        <label class="rvo-label" id="password-label" for="password">${msg("password")}</label>
-                        <#if usernameHidden?? && messagesPerField.existsError('username','password')>
-                          <div class="utrecht-form-field-description utrecht-form-field-description--invalid rvo-form-feedback rvo-form-feedback--error">
-                            <span id="input-error" class="utrecht-icon rvo-icon rvo-icon-foutmelding rvo-icon--md rvo-status-icon-foutmelding rvo-status-icon-foutmelding" aria-live="polite" role="img" aria-label="Foutmelding"></span>
-                            ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
-                          </div>
-                        </#if>
-                      </div>
-                      <input  tabindex="3" id="password" name="password" placeholder="" type="password" autocomplete="current-password" class="utrecht-textbox utrecht-textbox--html-input utrecht-textbox--lg"  aria-label="${msg("showPassword")}" aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"/>
-                    </div>
-                    <#if realm.resetPasswordAllowed>
-                    <div role="group" aria-labelledby="password-label" class="utrecht-form-field utrecht-form-field--text rvo-form-field" style="margin-block-start: -1em;">
-                      <div class="rvo-form-field__label">
-                        <a class="rvo-link" tabindex="6" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a>
-                      </div>
-                    </div>
-                    </#if>
-
-                    <#if realm.rememberMe && !usernameHidden??>
-                      <div class="rvo-checkbox__group">
-                        <label class="rvo-checkbox rvo-checkbox--not-checked" for="optionA-cb">
-                          <#if login.rememberMe??>
-                            <input tabindex="5" class="rvo-checkbox__input" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
-                          <#else>
-                            <input tabindex="5" class="rvo-checkbox__input" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
-                          </#if>
-                        </label>
-                      </div>
-                    </#if>
-                  </fieldset>
-                </div>
-
-                <p class="utrecht-button-group ">
-                    <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                    <input tabindex="7" class="utrecht-button utrecht-button--primary-action utrecht-button--rvo-md" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                </p>
-                <div></div>
-              </div>
-              </form>
-            </#if>
-          </div>
+                    </form>
+                </#if>
+            </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
     <#elseif section == "info">
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-        <div
-    class="rvo-alert rvo-alert--info rvo-alert--padding-md"
-    defaultargs="[object Object]"
-  >
+            <div
+                class="rvo-alert rvo-alert--info rvo-alert--padding-md"
+                defaultargs="[object Object]"
+            >
     <span
-      class="utrecht-icon rvo-icon rvo-icon-info rvo-icon--xl rvo-status-icon-info"
-      role="img"
-      aria-label="Info"
+        class="utrecht-icon rvo-icon rvo-icon-info rvo-icon--xl rvo-status-icon-info"
+        role="img"
+        aria-label="Info"
     ></span>
-    <div class="rvo-alert-text">
-      <div>
-        <div>
-         ${msg("noAccount")}
-          <a href="${url.registrationUrl}" class="rvo-link rvo-link--logoblauw" tabindex="8">${msg("doRegister")}</a>
-
-        </div>
-      </div>
-    </div>
-  </div>
+                <div class="rvo-alert-text">
+                    <div>
+                        <div>
+                            ${msg("noAccount")}
+                            <a href="${url.registrationUrl}" class="rvo-link rvo-link--logoblauw" tabindex="8">${msg("doRegister")}</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
             </div>
         </#if>
     <#elseif section == "socialProviders">
         <#if realm.password && social?? && social.providers?has_content>
-            <div class="rvo-layout-column">
-                    <div class="rvo-item-list">
-                        <div class="rvo-item-list__item">
-                                ${msg("identity-provider-login-label")}
-                        </div>
-                        <#list social.providers as p>
-                            <div class="rvo-item-list__item">
-                                <div
-                                    class="rvo-layout-row rvo-layout-justify-content-space-between rvo-layout-gap--sm rvo-layout--wrap"
-                                >
-                                    <a
-                                        id="social-${p.alias}"
-                                        class="rvo-link"
-                                        href="${p.loginUrl}"
-                                    >
-                                        ${p.displayName!}
-                                    </a>
-                                </div>
-                            </div>
-                        </#list>
-                    </div>
+            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+                <hr class="rvo-hr"/>
+                <h4 class="utrecht-heading-4">${msg("identity-provider-login-label")}</h4>
 
+                <div class="rvo-layout-column rvo-layout-align-items-center rvo-layout-gap--md">
+                    <#list social.providers as provider>
+                        <a id="social-${provider.alias}"
+                           class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-full-width rvo-button-group__align-right utrecht-button--rvo-md rvo-link--no-underline"
+                           type="button" href="${provider.loginUrl}">
+                            <#if provider.iconClasses?has_content>
+                                <span
+                                    class="utrecht-icon rvo-margin-inline-end--2xs rvo-icon rvo-icon--md rvo-icon--hemelblauw ${properties.kcCommonLogoIdP!} ${provider.iconClasses!}"
+                                    role="img"></span>
+                                <span
+                                    class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${provider.displayName!}</span>
+                            <#else>
+                                <span
+                                    class="${properties.kcFormSocialAccountNameClass!}">${provider.displayName!}</span>
+                            </#if>
+                        </a>
+                    </#list>
+                </div>
             </div>
         </#if>
     </#if>


### PR DESCRIPTION
- Extra templates toegevoegd voor flows waarbij username en wachtwoord los van elkaar ingevoerd worden. 
- Afbeelding van alternatieve IDP's aangepast zodat het meer lijkt op vormgeving van Keycloak en eigen wensen.
- Indenting in lijn gebracht met Keycloak templates