### PR TITLE
Social logins eerst tonen en eerste optie primair

### DIFF
--- a/theme/nl-design-system/login/login.ftl
+++ b/theme/nl-design-system/login/login.ftl
@@ -6,6 +6,10 @@
         <div id="kc-form">
             <div class="rvo-layout-column rvo-layout-gap--md">
                 <#if realm.password>
+                    <#if social?? && social.providers?has_content>
+                        <hr class="rvo-hr"/>
+                        <h4 class="utrecht-heading-4">${msg("identity-provider-login-label")}</h4>
+                    </#if>
                     <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                         <div class="rvo-layout-column rvo-layout-gap--md">
                             <div class="utrecht-form-fieldset rvo-form-fieldset">
@@ -95,28 +99,23 @@
         </#if>
     <#elseif section == "socialProviders">
         <#if realm.password && social?? && social.providers?has_content>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-                <hr class="rvo-hr"/>
-                <h4 class="utrecht-heading-4">${msg("identity-provider-login-label")}</h4>
-
-                <div class="rvo-layout-column rvo-layout-align-items-center rvo-layout-gap--md">
-                    <#list social.providers as provider>
-                        <a id="social-${provider.alias}"
-                           class="utrecht-button utrecht-button--secondary-action utrecht-button--rvo-full-width rvo-button-group__align-right utrecht-button--rvo-md rvo-link--no-underline"
-                           type="button" href="${provider.loginUrl}">
-                            <#if provider.iconClasses?has_content>
-                                <span
-                                    class="utrecht-icon rvo-margin-inline-end--2xs rvo-icon rvo-icon--md rvo-icon--hemelblauw ${properties.kcCommonLogoIdP!} ${provider.iconClasses!}"
-                                    role="img"></span>
-                                <span
-                                    class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${provider.displayName!}</span>
-                            <#else>
-                                <span
-                                    class="${properties.kcFormSocialAccountNameClass!}">${provider.displayName!}</span>
-                            </#if>
-                        </a>
-                    </#list>
-                </div>
+            <div id="kc-social-providers" class="rvo-layout-column rvo-layout-align-items-center rvo-layout-gap--md">
+                <#list social.providers as provider>
+                    <a id="social-${provider.alias}"
+                       class="utrecht-button <#if provider?index == 0>utrecht-button--primary-action<#else>utrecht-button--secondary-action</#if> utrecht-button--rvo-full-width rvo-button-group__align-right utrecht-button--rvo-md rvo-link--no-underline"
+                       type="button" href="${provider.loginUrl}">
+                        <#if provider.iconClasses?has_content>
+                            <span
+                                class="utrecht-icon rvo-margin-inline-end--2xs rvo-icon rvo-icon--md rvo-icon--hemelblauw ${properties.kcCommonLogoIdP!} ${provider.iconClasses!}"
+                                role="img"></span>
+                            <span
+                                class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${provider.displayName!}</span>
+                        <#else>
+                            <span
+                                class="${properties.kcFormSocialAccountNameClass!}">${provider.displayName!}</span>
+                        </#if>
+                    </a>
+                </#list>
             </div>
         </#if>
     </#if>

--- a/theme/nl-design-system/login/template.ftl
+++ b/theme/nl-design-system/login/template.ftl
@@ -189,6 +189,7 @@
               </div>
             </#if>
 
+            <#nested "socialProviders">
             <#nested "form">
 
             <#if auth?has_content && auth.showTryAnotherWayLink()>
@@ -209,8 +210,6 @@
                 </div>
               </form>
             </#if>
-
-            <#nested "socialProviders">
 
             <#if displayInfo>
               <#nested "info">


### PR DESCRIPTION
Voor overheidsinstanties is het logisch om te koppelen met de SSO/IDP van de betreffende instantie. Inloggen met een lokaal account is vaak alleen nuttig voor test-doeleinden of specifieke omstandigheden. Daarom is het logischer om "social providers" van keycloak eerst te tonen en daarna pas een username/password formulier.

Omdat het nu de eerste optie is, is het ook logisch om de eerste provider een primary-button te geven.

De scheiding met een lijn en kop wordt alleen getoond als beide opties er zijn.

Issue: https://github.com/MinBZK/keycloak-theme/issues/6
